### PR TITLE
Redis client refactor to use new options package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,12 +19,11 @@
 
 # Go workspace file
 go.work
-
+unpack.work.code-workspace
 
 # Workspace related files
 .unpack.toml
 build/*
-*.go.prototype
 .test.env
 data/bscscan/verified-contracts.gob
 data/db

--- a/clients/redis.go
+++ b/clients/redis.go
@@ -2,51 +2,70 @@ package clients
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/redis/go-redis/v9"
+	"github.com/txpull/unpack/options"
 )
 
+// Redis is a struct that holds the context, options, and the client for a Redis database.
 type Redis struct {
+	ctx    context.Context
+	opts   options.Redis
 	client *redis.Client
 }
 
-type Option func(*Redis)
-
-func RedisWithAddr(addr string) Option {
-	return func(r *Redis) {
-		r.client.Options().Addr = addr
-	}
-}
-
-func RedisWithPassword(password string) Option {
-	return func(r *Redis) {
-		r.client.Options().Password = password
-	}
-}
-
-func RedisWithDB(db int) Option {
-	return func(r *Redis) {
-		r.client.Options().DB = db
-	}
-}
-
-func NewRedis(options ...Option) (*Redis, error) {
+// NewRedis creates a new Redis client with the provided context and options.
+// It returns a pointer to the Redis struct and an error if any occurred during the creation of the client.
+func NewRedis(ctx context.Context, opts options.Redis) (*Redis, error) {
 	r := &Redis{
-		client: redis.NewClient(&redis.Options{}),
+		ctx:  ctx,
+		opts: opts,
+		client: redis.NewClient(&redis.Options{
+			Addr:            opts.Addr,
+			Password:        opts.Password,
+			DB:              opts.DB,
+			MaxRetries:      opts.MaxRetries,
+			MinRetryBackoff: opts.MinRetryBackoff * time.Millisecond,
+			MaxRetryBackoff: opts.MaxRetryBackoff * time.Millisecond,
+		}),
 	}
 
-	for _, option := range options {
-		option(r)
+	if err := r.ValidateOptions(); err != nil {
+		return nil, err
 	}
 
-	if resp := r.client.Ping(context.Background()); resp.Err() != nil {
+	if resp := r.client.Ping(ctx); resp.Err() != nil {
 		return nil, resp.Err()
 	}
 
 	return r, nil
 }
 
+// ValidateOptions checks the validity of the options used to create a Redis client.
+// It returns an error if any of the options are invalid.
+func (r *Redis) ValidateOptions() error {
+	if r.opts.Addr == "" {
+		return errors.New("addr cannot be empty")
+	}
+	if r.opts.DB < 0 {
+		return errors.New("db cannot be negative")
+	}
+	if r.opts.MaxRetries < 0 {
+		return errors.New("max retires cannot be negative")
+	}
+	if r.opts.MinRetryBackoff < 0 {
+		return errors.New("min retry backoff cannot be negative")
+	}
+	if r.opts.MaxRetryBackoff < 0 {
+		return errors.New("max retry backoff cannot be negative")
+	}
+	return nil
+}
+
+// Get retrieves the value of a key from the Redis database.
+// It returns the value as a byte slice and an error if any occurred during the retrieval.
 func (r *Redis) Get(ctx context.Context, key string) ([]byte, error) {
 	result, err := r.client.Get(ctx, key).Result()
 	if err != nil {
@@ -55,10 +74,14 @@ func (r *Redis) Get(ctx context.Context, key string) ([]byte, error) {
 	return []byte(result), nil
 }
 
+// Write sets the value of a key in the Redis database with an optional expiration duration.
+// It returns an error if any occurred during the write operation.
 func (r *Redis) Write(ctx context.Context, key string, value interface{}, expiration time.Duration) error {
 	return r.client.Set(ctx, key, value, expiration).Err()
 }
 
+// Exists checks if a key exists in the Redis database.
+// It returns a boolean indicating the existence of the key and an error if any occurred during the check.
 func (r *Redis) Exists(ctx context.Context, key string) (bool, error) {
 	resp, err := r.client.Exists(ctx, key).Result()
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,7 +28,7 @@ import (
 	"github.com/spf13/viper"
 	fixtures_cmd "github.com/txpull/unpack/cmd/fixtures"
 	syncers_cmd "github.com/txpull/unpack/cmd/syncers"
-	"github.com/txpull/unpack/helpers"
+	"github.com/txpull/unpack/options"
 	"go.uber.org/zap"
 )
 
@@ -53,7 +53,7 @@ func SetVersion(v string) {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
-	if err := helpers.InitConfig(cfgFile); err != nil {
+	if _, err := options.New(cfgFile); err != nil {
 		zap.L().Error("failed to initialize configuration", zap.Error(err))
 		os.Exit(1)
 	}

--- a/cmd/syncers/bscscan.go
+++ b/cmd/syncers/bscscan.go
@@ -32,6 +32,7 @@ import (
 	bscscan_crawler "github.com/txpull/unpack/crawlers/bscscan"
 	"github.com/txpull/unpack/db"
 	"github.com/txpull/unpack/db/models"
+	"github.com/txpull/unpack/options"
 	"github.com/txpull/unpack/scanners"
 	"go.uber.org/zap"
 )
@@ -58,11 +59,7 @@ var bscscanCmd = &cobra.Command{
 			zap.String("bscscan-csv-path", bscscanVerifiedCsvPath),
 		)
 
-		rdb, err := clients.NewRedis(
-			clients.RedisWithAddr(viper.GetString("database.redis.addr")),
-			clients.RedisWithPassword(viper.GetString("database.redis.password")),
-			clients.RedisWithDB(viper.GetInt("database.redis.db")),
-		)
+		rdb, err := clients.NewRedis(cmd.Context(), options.G().Database.Redis)
 		if err != nil {
 			return fmt.Errorf("failure to initialize redis client: %s", err)
 		}
@@ -75,7 +72,7 @@ var bscscanCmd = &cobra.Command{
 			viper.GetUint16("nodes.eth.archive.concurrent_clients_number"),
 		)
 		if err != nil {
-			return err
+			return fmt.Errorf("failure to initialize eth client: %s", err)
 		}
 
 		chainId, err := client.GetNetworkID(cmd.Context())

--- a/cmd/syncers/fourbyte.go
+++ b/cmd/syncers/fourbyte.go
@@ -32,6 +32,7 @@ import (
 	"github.com/txpull/unpack/crawlers/fourbyte"
 	"github.com/txpull/unpack/db"
 	"github.com/txpull/unpack/db/models"
+	"github.com/txpull/unpack/options"
 	"github.com/txpull/unpack/scanners"
 	"go.uber.org/zap"
 )
@@ -40,11 +41,7 @@ var fourbyteCmd = &cobra.Command{
 	Use:   "fourbyte",
 	Short: "Download, process and store signatures from 4byte.directory",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		rdb, err := clients.NewRedis(
-			clients.RedisWithAddr(viper.GetString("database.redis.addr")),
-			clients.RedisWithPassword(viper.GetString("database.redis.password")),
-			clients.RedisWithDB(viper.GetInt("database.redis.db")),
-		)
+		rdb, err := clients.NewRedis(cmd.Context(), options.G().Database.Redis)
 		if err != nil {
 			return fmt.Errorf("failure to initialize redis client: %s", err)
 		}

--- a/cmd/syncers/sourcify.go
+++ b/cmd/syncers/sourcify.go
@@ -33,6 +33,7 @@ import (
 	"github.com/txpull/unpack/crawlers/sourcify"
 	"github.com/txpull/unpack/db"
 	"github.com/txpull/unpack/db/models"
+	"github.com/txpull/unpack/options"
 	"github.com/txpull/unpack/scanners"
 	"go.uber.org/zap"
 )
@@ -41,11 +42,7 @@ var sourcifyCmd = &cobra.Command{
 	Use:   "sourcify",
 	Short: "Download, process and store contracts from sourcify.dev",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		rdb, err := clients.NewRedis(
-			clients.RedisWithAddr(viper.GetString("database.redis.addr")),
-			clients.RedisWithPassword(viper.GetString("database.redis.password")),
-			clients.RedisWithDB(viper.GetInt("database.redis.db")),
-		)
+		rdb, err := clients.NewRedis(cmd.Context(), options.G().Database.Redis)
 		if err != nil {
 			return fmt.Errorf("failure to initialize redis client: %s", err)
 		}

--- a/cmd/syncers/syncers.go
+++ b/cmd/syncers/syncers.go
@@ -27,7 +27,7 @@ import (
 
 // fixturesCmd represents the fixtures command
 var syncerCmd = &cobra.Command{
-	Use:   "syncer",
+	Use:   "syncers",
 	Short: "Commands related to syncing data from third party sources",
 }
 

--- a/unpacker/unpacker_test.go
+++ b/unpacker/unpacker_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/txpull/unpack/clients"
 	"github.com/txpull/unpack/db"
+	"github.com/txpull/unpack/options"
 	"github.com/txpull/unpack/readers"
 	"github.com/txpull/unpack/scanners"
 )
@@ -22,8 +23,11 @@ func TestGenericUnpacker(t *testing.T) {
 
 	// Redis is used to store cached unpacked contracts.
 	rdb, err := clients.NewRedis(
-		clients.RedisWithAddr(os.Getenv("REDIS_ADDR")),
-		clients.RedisWithPassword(os.Getenv("REDIS_PASSWORD")),
+		ctx,
+		options.Redis{
+			Addr:     os.Getenv("REDIS_ADDR"),
+			Password: os.Getenv("REDIS_PASSWORD"),
+		},
 	)
 	tAssert.NoError(err, "failure to initialize redis client")
 	tAssert.NotNil(rdb, "redis client is nil")


### PR DESCRIPTION
We are removing variadic functions as a way to set the configuration to the Redis client. Instead introducing `options.Redis` and applying `ValidateOptions` method to check for options.

Documentation of the redis client is included as well.